### PR TITLE
Remove k8s reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ class Program
 
 ## Wrapping Up
 
-This evolved repository mirrors production features: encrypted payloads, repeatable tests and full telemetry. Along the way we leaned on packages like `InfinityFlow.Aspire.Temporal` to manage the Temporal server and the Key Vault emulator to avoid external dependencies. Feel free to explore the `k8s` directory for deployment examples or the test suite for more advanced usage.
+This evolved repository mirrors production features: encrypted payloads, repeatable tests and full telemetry. Along the way we leaned on packages like `InfinityFlow.Aspire.Temporal` to manage the Temporal server and the Key Vault emulator to avoid external dependencies.
 
 Enjoy experimenting with .NET Aspire and Temporal!
 


### PR DESCRIPTION
## Summary
- remove reference to exploring the `k8s` directory from the README

## Testing
- `~/.dotnet/dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6851cd650ee0832bbcb7710663dcbe43